### PR TITLE
Fixing authorization bugs for items

### DIFF
--- a/app/items/discount/endpoints.py
+++ b/app/items/discount/endpoints.py
@@ -3,6 +3,7 @@ from app.JWT_auth.user_identification import UserIdentification
 from app.JWT_auth.authorization import authorization_wrapper
 from app.items.discount.model import ItemDiscountModel, ItemDiscountCreateModel
 import app.items.discount.db as discount_db
+import app.users.db as users_db
 from app.db_error_handler import handle_db_error
 import app.users.check as users_check
 
@@ -17,6 +18,10 @@ async def get_item_discounts(item_id: str, user_identification: UserIdentificati
 @router.post("/cinematic/items/{item_id}/discounts", tags=["discounts"], status_code=201)
 @handle_db_error
 async def create_item_discount(item_id: str, item_discount_data: ItemDiscountCreateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     discount_db.post_item_discount(item_id, item_discount_data)
     return {"info": "item discount successfully created"}
 
@@ -24,6 +29,10 @@ async def create_item_discount(item_id: str, item_discount_data: ItemDiscountCre
 @router.put("/cinematic/items/discounts/{discount_id}", tags=["discounts"], status_code=200)
 @handle_db_error
 async def edit_item_discount(discount_id: str, item_discount_data: ItemDiscountCreateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     discount_db.put_item_discount(discount_id, item_discount_data)
     return {"info": "item discount successfully updated"}
 
@@ -31,5 +40,9 @@ async def edit_item_discount(discount_id: str, item_discount_data: ItemDiscountC
 @router.delete("/cinematic/items/discounts/{discount_id}", tags=["discounts"], status_code=204)
 @handle_db_error
 async def delete_item_discount(discount_id: str, user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):    
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     discount_db.delete_item_discount(discount_id)
     return {"info": "item discount successfully deleted"}

--- a/app/items/inventory/endpoints.py
+++ b/app/items/inventory/endpoints.py
@@ -3,6 +3,7 @@ from app.JWT_auth.user_identification import UserIdentification
 from app.JWT_auth.authorization import authorization_wrapper
 from app.items.inventory.model import InventoryModel, InventoryCreateModel, InventoryUpdateModel
 import app.items.inventory.db as inventory_db
+import app.users.db as users_db
 from app.db_error_handler import handle_db_error
 import app.users.check as users_check
 
@@ -22,17 +23,29 @@ async def get_inventory_by_id(inventory_id: str, user_identification: UserIdenti
 @router.post("/cinematic/inventory", tags=["inventory"], status_code=201)
 @handle_db_error
 async def create_inventory(inventory_create_data: InventoryCreateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     inventory_db.post_inventory(inventory_create_data)
     return {"info": "inventory successfully created"}
 
 @router.put("/cinematic/inventory/{inventory_id}", tags=["inventory"], status_code=200)
 @handle_db_error
 async def edit_inventory(inventory_id: str, inventory_update_data: InventoryUpdateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     inventory_db.put_inventory(inventory_id, inventory_update_data)
     return {"info": "inventory successfully updated"}
 
 @router.delete("/cinematic/inventory/{inventory_id}", tags=["inventory"], status_code=204)
 @handle_db_error
 async def delete_inventory(inventory_id: str, user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     inventory_db.delete_inventory(inventory_id)
     return {"info": "inventory successfully deleted"}

--- a/app/items/item/endpoints.py
+++ b/app/items/item/endpoints.py
@@ -3,6 +3,7 @@ from app.JWT_auth.user_identification import UserIdentification
 from app.JWT_auth.authorization import authorization_wrapper
 from app.items.item.model import ItemCreateModel, ItemUpdateModel
 import app.items.item.db as item_db
+import app.users.db as users_db
 from app.db_error_handler import handle_db_error
 import app.users.check as users_check
 
@@ -11,7 +12,7 @@ router = fastapi.APIRouter()
 
 @router.get("/cinematic/items", tags=["items"], status_code=200)
 @handle_db_error
-async def get_all_items(user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
+async def get_all_items(user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):    
     return {"data": item_db.get_all_items()}
 
 
@@ -24,7 +25,10 @@ async def get_item_by_id(item_id: str, user_identification: UserIdentification =
 @router.post("/cinematic/items", tags=["items"], status_code=201)
 @handle_db_error
 async def create_item(item_create_data: ItemCreateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
-    # users_check.is_admin(user_id=user_identification.id)
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     item_db.post_item(item_create_data)
     return {"info": "item successfully inserted"}
 
@@ -32,7 +36,10 @@ async def create_item(item_create_data: ItemCreateModel = fastapi.Body(default=N
 @router.put("/cinematic/items/{item_id}", tags=["items"], status_code=200)
 @handle_db_error
 async def edit_item(item_id: str, item_update_data: ItemUpdateModel = fastapi.Body(default=None), user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
-    # users_check.is_admin(user_id=user_identification.id)
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     item_db.put_item(item_id, item_update_data)
     return {"info": "item successfully updated"}
 
@@ -40,7 +47,10 @@ async def edit_item(item_id: str, item_update_data: ItemUpdateModel = fastapi.Bo
 @router.delete("/cinematic/items/{item_id}", tags=["items"], status_code=204)
 @handle_db_error
 async def delete_item(item_id: str, user_identification: UserIdentification = fastapi.Depends(authorization_wrapper)):
-    # users_check.is_admin(user_id=user_identification.id)
+    
+    auth_user_cd = users_db.get_user_company_data(user_id=user_identification.id)
+    users_check.is_employee_or_higher(user_company_data=auth_user_cd)
+    
     item_db.delete_item(item_id)
     return {"info": "item successfully deleted"}
 


### PR DESCRIPTION
Fixed problem with all logged in users being able to read and manage Items, now only users logged in as employees or higher can manage (send POST, PUT, DELETE requests) items and all of the logged in users can read (send GET requests) items 